### PR TITLE
Add support for image/x-dcraw mime type

### DIFF
--- a/js/tabview.js
+++ b/js/tabview.js
@@ -40,7 +40,7 @@
             var mimetype = fileInfo.get('mimetype');
 
             return (['audio/flac', 'audio/mp4', 'audio/mpeg', 'audio/ogg', 'audio/wav',
-                'image/jpeg', 'image/tiff',
+                'image/jpeg', 'image/tiff', 'image/x-dcraw',
                 'video/3gpp', 'video/dvd', 'video/mp4', 'video/mpeg', 'video/quicktime',
                 'video/x-flv', 'video/x-matroska', 'video/x-msvideo'].indexOf(mimetype) > -1);
         },

--- a/lib/Controller/MetadataController.php
+++ b/lib/Controller/MetadataController.php
@@ -108,6 +108,13 @@ class MetadataController extends Controller {
                     }
                     break;
 
+                case 'image/x-dcraw':
+                    if ($sections = $this->readExif($file)) {
+                        $metadata = $this->getImageMetadata($sections, $lat, $lon);
+//                        $this->dump($sections, $metadata);
+                    }
+                    break;
+
                 default:
                     throw new Exception($this->language->t('Unsupported MIME type "%s".', array($mimetype)));
             }


### PR DESCRIPTION
The mimetype image/x-dcraw is used for several RAW image formats. The current implementation for getting the metadata works here too. Hence, I just necessary recognition of the mime type.