### PR TITLE
Upgrade code to new IEventDispatcher interface

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,6 +7,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 
+
 class Application extends App implements IBootstrap {
 	const APP_NAME = 'metadata';
 
@@ -25,7 +26,7 @@ class Application extends App implements IBootstrap {
 
 	public function boot(IBootContext $context): void {
 		$server = $context->getServerContainer();
-		$eventDispatcher = $server->getEventDispatcher();
+                $eventDispatcher = $this->getContainer()->query(IEventDispatcher::class);
 
 		$eventDispatcher->addListener('OCA\Files::loadAdditionalScripts', function() {
 			\OCP\Util::addStyle('metadata', 'tabview' );


### PR DESCRIPTION
This is required to make booting this app work on NC28.

NOTE: I haven't completed reviewed if this is all that is necessary to do to make it work on NC28, but it's what I needed to change to make the plugin work on NC28 and stop spamming the logs because it fails to boot.